### PR TITLE
Integrate pretty_yaml for the YAML formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,3 @@ jobs:
             .
             .github
             .vscode
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,17 +27,3 @@ jobs:
             .github
             .vscode
 
-  yamlfmt:
-    timeout-minutes: 15
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install mise
-        run: |
-          curl https://mise.jdx.dev/install.sh | sh
-          echo "$HOME/.local/share/mise/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/share/mise/shims" >> $GITHUB_PATH
-      - name: Install yamlfmt
-        # TODO: Apply selfup after https://github.com/google/yamlfmt/pull/180
-        run: mise use -g yamlfmt@0.12.1
-      - run: yamlfmt -lint .

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
     "editorconfig.editorconfig",
     "tekumara.typos-vscode",
     "dprint.dprint",
-    "kachick.vscode-yamlfmt",
     "jnoortheen.nix-ide"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,6 @@
 {
   "editor.defaultFormatter": "dprint.dprint",
   "editor.formatOnSave": true,
-  "[yaml]": {
-    "editor.defaultFormatter": "kachick.vscode-yamlfmt"
-  },
-  "[github-actions-workflow]": {
-    "editor.defaultFormatter": "kachick.vscode-yamlfmt"
-  },
   "[nix]": {
     "editor.defaultFormatter": "jnoortheen.nix-ide"
   },

--- a/dprint.json
+++ b/dprint.json
@@ -4,6 +4,9 @@
   },
   "markdown": {
   },
+  "yaml": {
+    "quotes": "preferSingle"
+  },
   "toml": {
   },
   "malva": {

--- a/dprint.json
+++ b/dprint.json
@@ -21,6 +21,6 @@
     "https://plugins.dprint.dev/sql-0.2.0.wasm",
     "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm",
     "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm",
-    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.1.0.wasm"
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.2.0.wasm"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -17,6 +17,7 @@
     "https://plugins.dprint.dev/toml-0.6.2.wasm",
     "https://plugins.dprint.dev/sql-0.2.0.wasm",
     "https://plugins.dprint.dev/g-plane/malva-v0.5.1.wasm",
-    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm"
+    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.10.0.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.1.0.wasm"
   ]
 }

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,7 +1,0 @@
-gitignore_excludes: true
-line_ending: lf
-formatter:
-  type: basic
-  retain_line_breaks_single: true
-  # https://github.com/google/yamlfmt/issues/182
-  scan_folded_as_literal: true


### PR DESCRIPTION
Resolves #129

ref: #92

- **`dprint config add g-plane/pretty_yaml`**
- **Prefer single quote for YAML strings to keep current style**
