### PR TITLE
Cache dprint WASM plugins in GHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           # To avoid rate limits on GitHub releases.
           path: ~/.dprint
-          key: dprint-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.DPRINT_VERSION }} # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}
+          key: dprint-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.DPRINT_VERSION }}
 
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           # We cache them to avoid GitHub API rate limits.
           # Revisit this cache logic once upstream supports it: https://github.com/dprint/check/issues/12
           path: ~/.cache/dprint
-          key: dprint-${{ hashFiles('dprint.json') }}
+          key: dprint-${{ hashFiles('dprint.json', 'dprint.jsonc') }}
 
       - uses: dprint/check@9cb3a2b17a8e606d37aae341e49df3654933fc23 # v2.3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           # We cache them to avoid GitHub API rate limits.
           # Revisit this cache logic once upstream supports it: https://github.com/dprint/check/issues/12
           path: ~/.cache/dprint
-          key: dprint-${{ hashFiles('dprint.json', 'dprint.jsonc') }}
+          key: dprint-wasm-plugins-${{ hashFiles('dprint.json', 'dprint.jsonc') }}
 
       - uses: dprint/check@9cb3a2b17a8e606d37aae341e49df3654933fc23 # v2.3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,18 @@ jobs:
   dprint:
     timeout-minutes: 15
     runs-on: ubuntu-slim
+    env:
+      DPRINT_VERSION: '0.54.0' # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - uses: actions/cache@v5
+        with:
+          # To avoid rate limits on GitHub releases.
+          path: ~/.dprint
+          key: dprint-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.DPRINT_VERSION }} # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}
 
       - uses: actions/cache@v5
         with:
@@ -26,7 +34,7 @@ jobs:
 
       - uses: dprint/check@9cb3a2b17a8e606d37aae341e49df3654933fc23 # v2.3
         with:
-          dprint-version: '0.54.0' # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}
+          dprint-version: ${{ env.DPRINT_VERSION }}
 
   typos:
     timeout-minutes: 15

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,8 @@ jobs:
       # exceeds the benefit, as the check action always runs anyway.
       - uses: actions/cache@v5
         with:
-          # WASM plugins only, so this cache works on any OS/arch
+          # WASM plugins only, so this cache works on any OS/arch.
+          # We cache them to avoid GitHub API rate limits.
           # Revisit this cache logic once upstream supports it: https://github.com/dprint/check/issues/12
           path: ~/.cache/dprint
           key: dprint-${{ hashFiles('dprint.json') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,19 +12,13 @@ jobs:
   dprint:
     timeout-minutes: 15
     runs-on: ubuntu-slim
-    env:
-      DPRINT_VERSION: '0.54.0' # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/cache@v5
-        with:
-          # To avoid rate limits on GitHub releases.
-          path: ~/.dprint
-          key: dprint-bin-${{ runner.os }}-${{ runner.arch }}-${{ env.DPRINT_VERSION }}
-
+      # We don't cache the dprint executable here because the overhead of caching it
+      # exceeds the benefit, as the check action always runs anyway.
       - uses: actions/cache@v5
         with:
           # WASM plugins only, so this cache works on any OS/arch
@@ -34,7 +28,7 @@ jobs:
 
       - uses: dprint/check@9cb3a2b17a8e606d37aae341e49df3654933fc23 # v2.3
         with:
-          dprint-version: ${{ env.DPRINT_VERSION }}
+          dprint-version: '0.54.0' # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}
 
   typos:
     timeout-minutes: 15

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - uses: actions/cache@v5
+        with:
+          # WASM plugins only, so this cache works on any OS/arch
+          # Revisit this cache logic once upstream supports it: https://github.com/dprint/check/issues/12
+          path: ~/.cache/dprint
+          key: dprint-${{ hashFiles('dprint.json') }}
+
       - uses: dprint/check@9cb3a2b17a8e606d37aae341e49df3654933fc23 # v2.3
         with:
           dprint-version: '0.54.0' # selfup {"extract":"\\d[^']+","replacer":["dprint", "--version"], "nth": 2}


### PR DESCRIPTION
This enables persistent caching for dprint plugins by using actions/cache@v5.
Since these plugins are WASM-based, the cache is independent of the OS
and architecture.

Assisted-by: Gemini:gemini-3.1
